### PR TITLE
allow pipeline scripts to run locally too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 node_modules
 *.zip
 nodejs
-
+buckets

--- a/pipeline/snapshot.py
+++ b/pipeline/snapshot.py
@@ -6,6 +6,7 @@ file into a JPG snapshot which is written to the target bucket.
 """
 from pathlib import Path
 from urllib.parse import unquote
+from shutil import copyfile
 
 import os
 import json
@@ -15,34 +16,47 @@ import boto3
 
 import ffmpeg
 
+LOCAL_BUCKETS_PATH = '../buckets'
+
 
 def main(event, context):
     '''Converts a video file into a jpg snapshot'''
-
-    # extract key and source bucket from incoming event
-    key = unquote(event['Records'][0]['s3']['object']['key'])
-    choir_id, song_id, part_id = Path(key).stem.split('.')[0].split('+')
-    bucket = event['Records'][0]['s3']['bucket']['name']
-    print('Running on %s/%s' % (bucket, key))
-
-    # get destination bucket from environment variable
-    dst_bucket = os.environ['DEST_BUCKET']
-    # geo = event['Records'][0]['awsRegion']
-
-    if key.endswith(".jpg"):
-        return {}
+    # local_mode is for writing to local files rather than S3
+    print('snapshot.py')
+    local_mode = bool(os.environ['LOCAL_MODE'])
+    print('Local mode %s' % (local_mode))
 
     # Get the service client.
     s3_client = boto3.client('s3')
 
-    # Generate the URL to get key from bucket
-    geturl = s3_client.generate_presigned_url(
-        ClientMethod='get_object',
-        Params={
-            'Bucket': bucket,
-            'Key': key
-        }
-    )
+    # get destination bucket from environment variable
+    dst_bucket = os.environ['DEST_BUCKET']
+
+    # extract key and source bucket from incoming event
+    if local_mode:
+        key = event['key']
+        bucket = event['bucket']
+        geturl = Path(LOCAL_BUCKETS_PATH, bucket, key)
+        desturl = Path(LOCAL_BUCKETS_PATH, dst_bucket, key + '.jpg')
+    else:
+        # when called from AWS S3 Event, the key/bucket are buried in the event
+        key = unquote(event['Records'][0]['s3']['object']['key'])
+        bucket = event['Records'][0]['s3']['bucket']['name']
+
+        # Generate the URL to get key from bucket
+        geturl = s3_client.generate_presigned_url(
+            ClientMethod='get_object',
+            Params={
+                'Bucket': bucket,
+                'Key': key
+            }
+        )
+
+    choir_id, song_id, part_id = Path(key).stem.split('.')[0].split('+')
+    print('Running on %s/%s' % (bucket, key))
+
+    if key.endswith(".jpg"):
+        return {}
 
     # Generate a temporary filename for the destination file
     keyjpg = key + '.jpg'
@@ -66,36 +80,31 @@ def main(event, context):
         # run ffmpeg
         try:
             out.run()
-            # upload temp file to S3
-            s3_client.upload_file(path, dst_bucket, keyjpg)
+
+            if local_mode:
+                # copy temp file to buckets path
+                copyfile(path, desturl)
+            else:
+                # upload temp file to S3
+                s3_client.upload_file(path, dst_bucket, keyjpg)
 
         except ffmpeg.Error as e:
             print("ffmpeg error. Trying to continue anyway...")
             print(e)
 
-    lambda_client = boto3.client('lambda')
+    # when running on Lambda, invoke the next Lambda
+    if not local_mode:
+        lambda_client = boto3.client('lambda')
 
-    #ret = {"snapshot_key": keyjpg,
-    #       "choir_id": choir_id,
-    #       "song_id": song_id,
-    #       "part_id": part_id,
-    #       "status": "new"}
+        ret = {"key": key,
+            "bucket": bucket,
+            "choir_id": choir_id,
+            "song_id": song_id,
+            "part_id": part_id}
 
-    #lambda_client.invoke(
-    #    FunctionName=os.environ['STATUS_LAMBDA'],
-    #    Payload=json.dumps(ret),
-    #    InvocationType='Event'
-    #)
+        lambda_client.invoke(
+            FunctionName=os.environ['CONVERT_LAMBDA'],
+            Payload=json.dumps(ret),
+            InvocationType='Event'
+        )
 
-    ret = {"key": key,
-           "bucket": bucket,
-           "choir_id": choir_id,
-           "song_id": song_id,
-           "part_id": part_id}
-
-    lambda_client.invoke(
-        FunctionName=os.environ['CONVERT_LAMBDA'],
-        Payload=json.dumps(ret),
-        InvocationType='Event'
-    )
-    return ret


### PR DESCRIPTION
In order to test whether the our pipeline scripts work correctly, we need to be able to execute them locally where they'll use local files instead of S3.

I've modified most of the pipeline scripts so that they can be executed locally - local mode is triggered with a `LOCAL_MODE` environment variable e.g.

```python
import snapshot
import os
os.environ['LOCAL_MODE'] = 'true'
os.environ['DEST_BUCKET'] = 'snapshots'
snapshot.main({
  'bucket': 'raw',
  'key': '001kfjgQ42CNxs0XIKnw3B71Yy2qus14+001kj2M82SK1WZ1w3CBT3uzSqS3BhXTH+001kjQbh2nOCht0dupTm3b2yPH04rExS.webm'
}, {}) 
```

> Note: we would need to modify the Terraform script to pass in a `TMP_DIR` environment variable with a value of `/mnt/tmp` to all Lambdas that connect to EFS in the VPC.